### PR TITLE
Add support for playlist item duration

### DIFF
--- a/rise-playlist.html
+++ b/rise-playlist.html
@@ -73,7 +73,7 @@
         }
 
         this.addEventListener("rise-component-ready", this.handleReady, false);
-        this.addEventListener("rise-component-done", this.handleDone);
+        this.addEventListener("rise-component-done", this.handleDone, false);
 
         this.loadingTimeout = setTimeout(function() {
           self.start();
@@ -132,6 +132,8 @@
           this.start();
           clearTimeout(this.loadingTimeout);
         }
+
+        e.stopPropagation();
       },
 
       /**
@@ -153,23 +155,38 @@
             break;
           }
         }
+
+        e.stopPropagation();
       },
 
       /**
        * Play a playlist item.
        */
       play: function(index) {
-        var item;
+        var self = this,
+          item = null,
+          duration = null;
 
         if ((index >= 0) && (index < this.items.length)) {
           item = this.items[index];
+          duration = this.$.items.getDistributedNodes()[index].getAttribute("duration");
 
           this.hide();
 
           // Show the current playlist item.
           item.element.style.visibility = "visible";
 
-          // Play the current playlist item.
+          // Play the next item after the current one has completed.
+          if (duration !== null) {
+            duration = parseInt(duration, 10);
+
+            if (!isNaN(duration)) {
+              setTimeout(function() {
+                self.playNext(index, "pause");
+              }, duration * 1000);
+            }
+          }
+
           this.sendCommand(item, "play");
         }
       },

--- a/test/index.html
+++ b/test/index.html
@@ -12,7 +12,8 @@
     <script>
       WCT.loadSuites([
         "rise-playlist-ready.html",
-        "rise-playlist-not-ready.html"
+        "rise-playlist-not-ready.html",
+        "rise-playlist-duration.html",
       ]);
     </script>
   </body>

--- a/test/rise-playlist-duration.html
+++ b/test/rise-playlist-duration.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Playlist Items - Duration</title>
+
+  <script src="../../webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../rise-playlist.html">
+  <link rel="import" href="../../web-component-rise-playlist-item/rise-playlist-item.html">
+  <link rel="import" href="rise-demo.html">
+</head>
+<body>
+  <rise-playlist id="playlist">
+
+    <rise-playlist-item duration="10">
+      <rise-demo id="first">
+        <nested-element></nested-element>
+      </rise-demo>
+    </rise-playlist-item>
+
+    <rise-playlist-item duration="5">
+      <rise-demo id="second"></rise-demo>
+    </rise-playlist-item>
+
+    <rise-playlist-item duration="invalid">
+      <rise-demo id="third"></rise-demo>
+    </rise-playlist-item>
+
+  </rise-playlist>
+
+  <script>
+    suite("duration", function() {
+      var clock = sinon.useFakeTimers(),
+        playlist = document.querySelector("#playlist"),
+        first = document.querySelector("#first"),
+        second = document.querySelector("#second"),
+        third = document.querySelector("#third"),
+        firstSpy = null,
+        secondSpy = null,
+        thirdSpy = null;
+
+      suiteSetup(function() {
+        first.onReady();
+        firstSpy = sinon.spy(playlist.items[0], "play");
+
+        second.onReady();
+        secondSpy = sinon.spy(playlist.items[1], "play");
+
+        third.onReady();
+        thirdSpy = sinon.spy(playlist.items[2], "play");
+      });
+
+      suiteTeardown(function() {
+        clock.restore();
+
+        playlist.items[0].play.restore();
+        playlist.items[1].play.restore();
+        playlist.items[2].play.restore();
+      });
+
+      test("should play first item for 10 seconds followed by second item", function() {
+        assert(firstSpy.calledOnce, "first item is playing");
+
+        clock.tick(9999);
+
+        assert(secondSpy.notCalled, "second item is not yet playing");
+
+        clock.tick(1);
+
+        assert(secondSpy.calledOnce, "second item is playing");
+      });
+
+      test("should play second item for 5 seconds followed by third item", function() {
+        clock.tick(4999);
+
+        assert(thirdSpy.notCalled, "third item is not yet playing");
+
+        clock.tick(1);
+
+        assert(thirdSpy.calledOnce, "third item is playing");
+      });
+    });
+  </script>
+</body>
+</html>

--- a/test/rise-playlist-not-ready.html
+++ b/test/rise-playlist-not-ready.html
@@ -9,6 +9,7 @@
   <script src="../../web-component-tester/browser.js"></script>
 
   <link rel="import" href="../rise-playlist.html">
+  <link rel="import" href="../../web-component-rise-playlist-item/rise-playlist-item.html">
   <link rel="import" href="rise-demo.html">
 </head>
 <body>

--- a/test/rise-playlist-ready.html
+++ b/test/rise-playlist-ready.html
@@ -9,6 +9,7 @@
   <script src="../../web-component-tester/browser.js"></script>
 
   <link rel="import" href="../rise-playlist.html">
+  <link rel="import" href="../../web-component-rise-playlist-item/rise-playlist-item.html">
   <link rel="import" href="rise-demo.html">
 </head>
 <body>


### PR DESCRIPTION
- Add support for playlist item duration. After the item has been shown for the specified duration, its pause function will be called and the next item will play.
- Prevent further propagation of `rise-component-ready` and `rise-component-done` events.
- Add missing imports of `rise-playlist-item` web components in test files.
