### PR TITLE
Change how content syncing works

### DIFF
--- a/rise-playlist.html
+++ b/rise-playlist.html
@@ -27,7 +27,7 @@
     },
 
     /**
-     * The playlist items that have reported as being ready.
+     * The playlist items.
      */
     _items: [],
 
@@ -44,7 +44,7 @@
     /**
      * The delay (in ms) for the timeout that fires if not all playlist items have reported ready.
      */
-    _loadingDelay: 30000,
+    _loadingDelay: 5000,
 
     /************************************** INITIALIZATION **************************************/
 
@@ -56,10 +56,12 @@
 
       for (var i = 0; i < nodes.length; i++) {
         if (nodes[i].nodeType === 1) {
+          this._addItem(nodes[i]);
           this._totalItems++;
         }
       }
 
+      this._hideAll();
       this.addEventListener("rise-component-ready", this._handleReady, false);
       this.addEventListener("rise-component-done", this._handleDone, false);
 
@@ -68,34 +70,20 @@
       }, this._loadingDelay);
     },
 
-    /**
-     * Remove the event listener so that it won't be triggered by late-loading playlist items.
-     */
-    _start: function() {
-      if (this._items.length > 0) {
-        this._sortItems();
-        this._calculateDuration();
-        this._hideAll();
-        this.play(0);
-        this.removeEventListener("rise-component-ready", this._handleReady, false);
-      }
-    },
-
-    /***************************************** PLAYBACK *****************************************/
+    /*************************************** EVENT HANDLERS ***************************************/
 
     /**
-     * Add the playlist item to the items map if it does not already exist.
+     * Add more details about a particular content element once it's ready.
      */
     _handleReady: function(e) {
-      var item = {};
+      var item = _.findWhere(this._items, { id: e.target.id });
 
-      // Playlist item has already been added.
-      if (_.findWhere(this._items, { id: e.target.id }) !== undefined) {
+      // No content element with this id was found or it has already reported ready.
+      if ((item === undefined) || item.isReady) {
         return;
       }
 
-      item.id = e.target.id;
-      item.element = e.target;
+      item.isReady = true;
 
       if (e.detail) {
         if (e.detail.play) {
@@ -115,7 +103,6 @@
         }
       }
 
-      this._items.push(item);
       this._numItems++;
 
       if (this._numItems === this._totalItems) {
@@ -154,6 +141,17 @@
       e.stopPropagation();
     },
 
+    /****************************************** PLAYBACK ******************************************/
+
+    /**
+     * Start playlist playback.
+     */
+    _start: function() {
+      if (this._items.length > 0) {
+        this.play(0);
+      }
+    },
+
     /**
      * Play a playlist item.
      */
@@ -162,7 +160,7 @@
         duration;
 
       if (item !== null) {
-        duration = this._getDuration(index);
+        duration = item.duration;
 
         // Play the next item after the current one has completed.
         if (duration !== 0) {
@@ -171,8 +169,11 @@
           }, duration);
         }
 
-        this._show(index);
-        this._sendCommand(item, "play");
+        // Only play and show the item if it's ready.
+        if (item.isReady) {
+          this._show(index);
+          this._sendCommand(item, "play");
+        }
       }
     },
 
@@ -207,6 +208,47 @@
       this._playNext(index, "stop");
     },
 
+    /************************************** HELPER FUNCTIONS **************************************/
+
+    /**
+     * Add the content element of a playlist item to _items.
+     */
+    _addItem: function(playlistItem) {
+      var item = {},
+        contentElement = null,
+        duration = this._getDuration(playlistItem);
+
+      contentElement = this._getContentElement(playlistItem);
+
+      if (contentElement) {
+        item.isReady = false;
+        item.duration = duration;
+        item.id = contentElement.id;
+        item.element = contentElement;
+
+        this._items.push(item);
+      }
+    },
+
+    /**
+     * Get the content element nested inside of the playlist item.
+     */
+    _getContentElement: function(playlistItem) {
+      var children = null;
+
+      if (playlistItem && playlistItem.hasChildNodes()) {
+        children = playlistItem.childNodes;
+
+        for (var i = 0; i < children.length; i++) {
+          if (children[i].nodeType === 1) {
+            return children[i];
+          }
+        }
+      }
+
+      return null;
+    },
+
     /**
      * Get a playlist item by index.
      */
@@ -221,106 +263,24 @@
     },
 
     /**
-     * Get the duration of a particular playlist item.
+     * Get the duration of a playlist item.
      */
-    _getDuration: function(index) {
-      var item = this._items[index];
+    _getDuration: function(playlistItem) {
+      var duration = 0;
 
-      if (item.hasOwnProperty("duration")) {
-        return item.duration;
+      if (playlistItem && playlistItem.hasAttribute("duration")) {
+        duration = parseInt(playlistItem.getAttribute("duration"), 10);
+
+        // Invalid duration
+        if (isNaN(duration)) {
+          duration = 0;
+        }
       }
       else {
-        return 0;
-      }
-    },
-
-    /**
-     * Sort playlist items.
-     */
-    _sortItems: function() {
-      var items = Polymer.dom(this.$.items).getDistributedNodes(),
-        componentId = "",
-        children = null,
-        newItems = [];
-
-      // Iterate over playlist items.
-      for (var i = 0; i < items.length; i++) {
-        if ((items[i].nodeType === 1) && items[i].hasChildNodes()) {
-          children = items[i].childNodes;
-
-          // Iterate over children of current playlist item.
-          for (var j = 0; j < children.length; j++) {
-            if (children[j].nodeType === 1) {
-              componentId = children[j].id;
-
-              // Find the matching element in _items array, if applicable.
-              for (var k = 0; k < this._items.length; k++) {
-                if (componentId === this._items[k].id) {
-                  newItems.push(this._items[k]);
-
-                  break;
-                }
-              }
-
-              break;
-            }
-          }
-        }
+        duration = 0;
       }
 
-      this._items = newItems;
-    },
-
-    /**
-     * Calculate the duration of all playlist items.
-     */
-    _calculateDuration: function() {
-      var items = Polymer.dom(this.$.items).getDistributedNodes(),
-        contentId = "",
-        children = null,
-        duration = 0,
-        totalDuration = 0;
-
-      // Iterate over the playlist item nodes.
-      for (var i = 0; i < items.length; i++) {
-        // Found the rise-playlist-item node.
-        if ((items[i].nodeType === 1) && items[i].hasChildNodes()) {
-          children = items[i].childNodes;
-
-          if (items[i].hasAttribute("duration")) {
-            duration = parseInt(items[i].getAttribute("duration"), 10);
-
-            if (isNaN(duration)) {
-              duration = 0;
-            }
-          }
-          else {
-            duration = 0;
-          }
-
-          totalDuration += duration;
-
-          // Iterate over children of current rise-playlist-item node.
-          for (var j = 0; j < children.length; j++) {
-            // Found the content node.
-            if (children[j].nodeType === 1) {
-              contentId = children[j].id;
-
-              // Find the matching element in the _items array, if applicable.
-              for (var k = 0; k < this._items.length; k++) {
-                if (contentId === this._items[k].id) {
-                  this._items[k].duration = totalDuration * 1000;
-                  totalDuration = 0;
-
-                  break;
-                }
-              }
-
-              break;
-            }
-          }
-        }
-      }
+      return duration * 1000;
     },
 
     /**

--- a/test/integration/rise-playlist-content-sync.html
+++ b/test/integration/rise-playlist-content-sync.html
@@ -23,20 +23,8 @@
       <rise-demo id="item-1"></rise-demo>
     </rise-playlist-item>
 
-    <rise-playlist-item duration="10">
-      <rise-demo id="item-2"></rise-demo>
-    </rise-playlist-item>
-
     <rise-playlist-item duration="5">
-      <rise-demo id="item-3"></rise-demo>
-    </rise-playlist-item>
-
-    <rise-playlist-item duration="5">
-      <rise-demo id="item-4"></rise-demo>
-    </rise-playlist-item>
-
-    <rise-playlist-item duration="60">
-      <rise-demo id="item-5">
+      <rise-demo id="item-2">
         <nested-element></nested-element>
       </rise-demo>
     </rise-playlist-item>
@@ -46,96 +34,70 @@
   <script>
     suite("content sync", function() {
       var playlist = document.querySelector("#playlist"),
+        item1 = document.querySelector("#item-1"),
+        item2 = document.querySelector("#item-2"),
         readySpy = null,
-        item2PlaySpy = null,
-        item4PlaySpy = null,
-        item5PlaySpy = null,
-        item2PauseSpy = null,
-        item4PauseSpy = null,
-        item5PauseSpy = null;
+        playSpy = null,
+        pauseSpy = null;
 
       suiteSetup(function() {
         document.querySelector("#item-2").onReady();
-        document.querySelector("#item-4").onReady();
-        document.querySelector("#item-5").onReady();
 
         readySpy = sinon.spy(playlist, "_handleReady");
-        item2PlaySpy = sinon.spy(playlist._items[0], "play");
-        item4PlaySpy = sinon.spy(playlist._items[1], "play");
-        item5PlaySpy = sinon.spy(playlist._items[2], "play");
-        item2PauseSpy = sinon.spy(playlist._items[0], "pause");
-        item4PauseSpy = sinon.spy(playlist._items[1], "pause");
-        item5PauseSpy = sinon.spy(playlist._items[2], "pause");
+        playSpy = sinon.spy(playlist._items[1], "play");
+        pauseSpy = sinon.spy(playlist._items[1], "pause");
 
-        clock.tick(30000);
+        clock.tick(5000);
       });
 
       suiteTeardown(function() {
         clock.restore();
 
         playlist._handleReady.restore();
-        playlist._items[0].play.restore();
         playlist._items[1].play.restore();
-        playlist._items[2].play.restore();
-        playlist._items[0].pause.restore();
         playlist._items[1].pause.restore();
-        playlist._items[2].pause.restore();
       });
 
       test("should have correct number of items in the _items array", function() {
-        assert.equal(playlist._items.length, 3);
+        assert.equal(playlist._items.length, 2);
       });
 
-       test("should sort the _items array in the same order as the items appear in the playlist", function() {
-        assert.equal(playlist._items[0].id, "item-2", "item-2");
-        assert.equal(playlist._items[1].id, "item-4", "item-4");
-        assert.equal(playlist._items[2].id, "item-5", "item-5");
+      test("should hide all items", function() {
+        assert(item1.style.display === "none", "item-1 is hidden");
+        assert(item2.style.display === "none", "item-2 is hidden");
       });
 
-      test("should not call ready event handler after the loading timer has expired", function() {
-        assert(readySpy.notCalled);
-      });
-
-      test("should start playing item-2 after the loading timer has expired", function() {
-        assert(item2PlaySpy.calledOnce);
-      });
-
-      test("should play item-2 for the combined duration of item-1 and item-2", function() {
-        clock.tick(19999);
-
-        assert(item2PauseSpy.notCalled, "item-2 is still playing");
-
-        clock.tick(1);
-
-        assert(item2PauseSpy.calledOnce, "item-2 is paused");
-      });
-
-      test("should play item-4 for the combined duration of item-3 and item-4", function() {
-        assert(item4PlaySpy.calledOnce, "item-4 is playing");
+      test("should hide item-1 for its entire duration", function() {
+        assert(item1.style.display === "none", "item-1 is hidden");
 
         clock.tick(9999);
 
-        assert(item4PauseSpy.notCalled, "item-4 is still playing");
+        assert(item1.style.display === "none", "item-1 is still hidden");
+      });
+
+      test("should play and show item-2", function() {
+        assert(item2.style.display === "none", "item-2 is hidden");
+        assert(playSpy.notCalled, "item-2 is not playing");
 
         clock.tick(1);
 
-        assert(item4PauseSpy.calledOnce, "item-4 is paused");
+        assert(item2.style.display === "block", "item-2 is visible");
+        assert(playSpy.calledOnce, "item-2 is playing");
       });
 
-      test("should play item-5 for its specified duration", function() {
-        assert(item5PlaySpy.calledOnce, "item-5 is playing");
+      test("should pause and hide item-2", function() {
+        clock.tick(5000);
 
-        clock.tick(59999);
-
-        assert(item5PauseSpy.notCalled, "item-5 is still playing");
-
-        clock.tick(1);
-
-        assert(item5PauseSpy.calledOnce, "item-5 is paused");
+        assert(item2.style.display === "none", "item-2 is hidden");
+        assert(pauseSpy.calledOnce, "item-2 is paused");
       });
 
-      test("should start playing item-2 after the last item has finished", function() {
-        assert(item2PlaySpy.calledTwice);
+      test("should hide item-1 for its entire duration after the last playlist item has finished", function() {
+        assert(item1.style.display === "none", "item-1 is hidden");
+
+        clock.tick(9999);
+
+        assert(item1.style.display === "none", "item-1 is still hidden");
       });
     });
   </script>

--- a/test/unit/rise-playlist-content-sync.html
+++ b/test/unit/rise-playlist-content-sync.html
@@ -8,10 +8,6 @@
   <script src="../../../webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../web-component-tester/browser.js"></script>
 
-  <script>
-    var clock = sinon.useFakeTimers();
-  </script>
-
   <link rel="import" href="../../rise-playlist.html">
   <link rel="import" href="../../../rise-playlist-item/rise-playlist-item.html">
   <link rel="import" href="../rise-demo.html">
@@ -19,101 +15,94 @@
 <body>
   <rise-playlist id="playlist">
 
-    <rise-playlist-item duration="10">
+    <rise-playlist-item id="single-item" duration="10">
       <rise-demo id="item-1"></rise-demo>
     </rise-playlist-item>
 
-    <rise-playlist-item duration="10">
+    <rise-playlist-item id="no-items" duration="invalid">
+    </rise-playlist-item>
+
+    <rise-playlist-item id="multiple-items">
       <rise-demo id="item-2"></rise-demo>
-    </rise-playlist-item>
-
-    <rise-playlist-item>
       <rise-demo id="item-3"></rise-demo>
-    </rise-playlist-item>
-
-    <rise-playlist-item duration="5">
-      <rise-demo id="item-4"></rise-demo>
-    </rise-playlist-item>
-
-    <rise-playlist-item duration="invalid">
-      <rise-demo id="item-5"></rise-demo>
-    </rise-playlist-item>
-
-    <rise-playlist-item duration="15">
-      <rise-demo id="item-6"></rise-demo>
-    </rise-playlist-item>
-
-    <rise-playlist-item duration="60">
-      <rise-demo id="item-7"></rise-demo>
-    </rise-playlist-item>
-
-    <rise-playlist-item>
-      <rise-demo id="item-8"></rise-demo>
-    </rise-playlist-item>
-
-    <rise-playlist-item duration="invalid">
-      <rise-demo id="item-9"></rise-demo>
     </rise-playlist-item>
 
   </rise-playlist>
 
   <script>
     suite("content sync", function() {
-      var playlist = document.querySelector("#playlist");
+      var playlist = document.querySelector("#playlist"),
+        singleItem = document.querySelector("#single-item"),
+        noItems = document.querySelector("#no-items"),
+        multipleItems = document.querySelector("#multiple-items"),
+        item1 = document.querySelector("#item-1");
 
       suiteSetup(function() {
-        document.querySelector("#item-2").onReady();
-        document.querySelector("#item-4").onReady();
-        document.querySelector("#item-6").onReady();
-        document.querySelector("#item-7").onReady();
-        document.querySelector("#item-8").onReady();
-        document.querySelector("#item-9").onReady();
-
-        clock.tick(30000);
+        playlist._items = [];
       });
 
-      suiteTeardown(function() {
-        clock.restore();
+      suite("_addItem", function() {
+        test("should add the content element to _items", function() {
+          playlist._addItem(singleItem);
+
+          assert.equal(playlist._items.length, 1);
+        });
+
+        test("should correctly set isReady property", function() {
+          assert.equal(playlist._items[0].isReady, false);
+        });
+
+        test("should correctly set duration property", function() {
+          assert.equal(playlist._items[0].duration, 10000);
+        });
+
+        test("should correctly set id property", function() {
+          assert.equal(playlist._items[0].id, "item-1");
+        });
+
+        test("should correctly set element property", function() {
+          assert.equal(playlist._items[0].element, item1);
+        });
+
+        test("should not add a new element to _items if a playlist item does not have any content", function() {
+          playlist._addItem(noItems);
+
+          assert.equal(playlist._items.length, 1);
+        });
+
+        test("should add the first content element to _items if a playlist item has multiple content elements", function() {
+          playlist._addItem(multipleItems);
+
+          assert.equal(playlist._items.length, 2, "length");
+          assert.equal(playlist._items[1].id, "item-2", "id");
+        });
       });
 
-      suite("_calculateDuration", function() {
-        test("should correctly set the duration property for an item when the item before it has a " +
-          "duration and is not ready", function() {
-          assert.equal(playlist._items[0].duration, 20000);
+      suite("_getContentElement", function() {
+        test("should return the content element inside a playlist item", function() {
+          assert.equal(playlist._getContentElement(singleItem), item1);
         });
 
-        test("should correctly set the duration property for an item when the item before it has no " +
-          "duration and is not ready", function() {
-          assert.equal(playlist._items[1].duration, 5000);
+        test("should return null if a playlist item does not have any content", function() {
+          assert.isNull(playlist._getContentElement(noItems));
         });
 
-        test("should correctly set the duration property for an item when the item before it has an " +
-          "invalid duration and is not ready", function() {
-          assert.equal(playlist._items[2].duration, 15000);
-        });
-
-        test("should correctly set the duration property for an item when it has a valid duration", function() {
-          assert.equal(playlist._items[3].duration, 60000);
-        });
-
-        test("should correctly set the duration property for an item when it doesn't have a duration", function() {
-          assert.equal(playlist._items[4].duration, 0);
-        });
-
-        test("should correctly set the duration property for an item when it has an invalid duration", function() {
-          assert.equal(playlist._items[5].duration, 0);
+        test("should return the first content element if a playlist item has multiple content elements", function() {
+          assert.equal(playlist._getContentElement(multipleItems), document.querySelector("#item-2"));
         });
       });
 
       suite("_getDuration", function() {
-        test("should return correct duration for an item", function() {
-          assert.equal(playlist._getDuration(0), 20000);
+        test("should return correct duration of a playlist item", function() {
+          assert.equal(playlist._getDuration(singleItem), 10000);
         });
 
-        test("should return 0 if an item has no duration property", function() {
-          delete playlist._items[0].duration;
+        test("should return 0 if a playlist item has an invalid duration", function() {
+          assert.equal(playlist._getDuration(noItems), 0);
+        });
 
-          assert.equal(playlist._getDuration(0), 0);
+        test("should return 0 if a playlist item has no duration", function() {
+          assert.equal(playlist._getDuration(multipleItems), 0);
         });
       });
     });

--- a/test/unit/rise-playlist.html
+++ b/test/unit/rise-playlist.html
@@ -45,22 +45,13 @@
       });
 
       suite("_handleReady", function() {
-        suiteTeardown(function() {
-          playlist._handleReady.restore();
-        });
-
-        test("should add an item to the items property", function() {
+        suiteSetup(function() {
+          first.onReady();
           second.onReady();
-
-          assert.equal(playlist._items.length, 1);
         });
 
-        test("should store the id", function() {
-          assert.equal(playlist._items[0].id, "second");
-        });
-
-        test("should store the element", function() {
-          assert.isObject(playlist._items[0].element);
+        test("should correctly set isReady property", function() {
+          assert.equal(playlist._items[0].isReady, true);
         });
 
         test("should store the play function", function() {
@@ -79,28 +70,14 @@
           assert.isBoolean(playlist._items[0].done);
         });
 
-        test("should increment numItems", function() {
-          assert.equal(playlist._numItems, 1);
+        test("should increment _numItems", function() {
+          assert.equal(playlist._numItems, 2);
         });
 
-        test("should not add an item to the items property if it already exists", function() {
+        test("should not increment _numItems if an item fires the ready event more than once", function() {
           second.onReady();
 
-          assert.equal(playlist._items.length, 1);
-        });
-
-        test("should sort the items array in the same order as the playlist items appear in the playlist", function() {
-          first.onReady();
-
-          assert.equal(playlist._items[0].id, "first", "first playlist item");
-          assert.equal(playlist._items[1].id, "second", "second playlist item");
-        });
-
-        test("should not call ready event handler again once all playlist items are ready", function() {
-          spy = sinon.spy(playlist, "_handleReady");
-          first.onReady();
-
-          assert(spy.notCalled);
+          assert.equal(playlist._numItems, 2);
         });
       });
 


### PR DESCRIPTION
Key decision points:
- Content that is ready will start to show within 5 seconds instead of 30.
- If a content item isn't ready, blank space will be shown rather than extending the duration of the content item that follows it. As a consequence, `_items` now contains all content items, and not just those that are ready. This also eliminates the need for any sorting functionality.
- Listen for `rise-component-ready` indefinitely as opposed to removing the event handler after 30 seconds or after all content has reported as being ready.
