### PR TITLE
Playlist playback is controlled externally

### DIFF
--- a/rise-playlist.html
+++ b/rise-playlist.html
@@ -54,6 +54,8 @@
     attached: function() {
       var nodes = Polymer.dom(this.$.items).getDistributedNodes();
 
+      this._items = [];
+
       for (var i = 0; i < nodes.length; i++) {
         if (nodes[i].nodeType === 1) {
           this._addItem(nodes[i]);
@@ -70,7 +72,16 @@
       }, this._loadingDelay);
     },
 
-    /*************************************** EVENT HANDLERS ***************************************/
+    _dispatchReady: function() {
+      var readyEvent = new CustomEvent("rise-playlist-ready", {
+        "detail": {
+          "items": this._items
+        },
+        "bubbles": true
+      });
+
+      this.dispatchEvent(readyEvent);
+    },
 
     /**
      * Add more details about a particular content element once it's ready.
@@ -113,34 +124,6 @@
       e.stopPropagation();
     },
 
-    /**
-     * Play the next item in the playlist.
-     */
-    _handleDone: function(e) {
-      var nextIndex,
-        item = null,
-        itemsLength = this._items.length;
-
-      // Find current playlist item.
-      for (var index = 0; index < itemsLength; index++) {
-        if (this._items[index].id === e.target.id) {
-          item = this._items[index];
-          nextIndex = (index + 1 < itemsLength) ? (index + 1): 0;
-
-          // Current playlist item
-          this._hide(index);
-          this._sendCommand(item, "pause");
-
-          // Next playlist item
-          this.play(nextIndex);
-
-          break;
-        }
-      }
-
-      e.stopPropagation();
-    },
-
     /****************************************** PLAYBACK ******************************************/
 
     /**
@@ -148,7 +131,7 @@
      */
     _start: function() {
       if (this._items.length > 0) {
-        this.play(0);
+        this._dispatchReady();
       }
     },
 
@@ -156,40 +139,49 @@
      * Play a playlist item.
      */
     play: function(index) {
-      var item = this._getItem(index),
-        duration;
+      var item = this._getItem(index);
 
-      if (item !== null) {
-        duration = item.duration;
-
-        // Play the next item after the current one has completed.
-        if (duration !== 0) {
-          this.debounce("play-next", function() {
-            this._playNext(index, "pause");
-          }, duration);
-        }
-
-        // Only play and show the item if it's ready.
-        if (item.isReady) {
-          this._show(index);
-          this._sendCommand(item, "play");
-        }
+      // Only play and show the item if it's ready.
+      if ((item !== null) && item.isReady) {
+        this._show(index);
+        this._sendCommand(item, "play");
       }
     },
 
     /**
-     * Play the next item in a playlist.
+     * Suspend playback of a playlist item.
      */
-    _playNext: function(index, command) {
-      var item = this._getItem(index),
-        nextIndex = (index + 1 < this._items.length) ? (index + 1) : 0;
+    _suspend: function(index, command) {
+      var item = this._getItem(index);
 
       if (item !== null) {
-        // Current playlist item
         this._hide(index);
         this._sendCommand(item, command);
+      }
+    },
 
-        // Next playlist item
+    /**
+     * Play the next item in the playlist.
+     */
+    _playNext: function(index) {
+      var duration,
+        nextIndex = this._getNextIndex(index),
+        nextItem = this._getItem(nextIndex);
+
+      // Suspend current item.
+      this._suspend(index, "pause");
+
+      // Play next item.
+      if ((nextItem !== null) && nextItem.isReady) {
+        duration = nextItem.duration;
+
+        // Ensure the item plays for its specified duration.
+        if (duration !== 0) {
+          this.debounce("play-next", function() {
+            this._playNext(nextIndex);
+          }, duration);
+        }
+
         this.play(nextIndex);
       }
     },
@@ -198,14 +190,30 @@
      * Pause a playlist item.
      */
     pause: function(index) {
-      this._playNext(index, "pause");
+      this._suspend(index, "pause");
     },
 
     /**
      * Stop a playlist item.
      */
     stop: function(index) {
-      this._playNext(index, "stop");
+      this._suspend(index, "stop");
+    },
+
+    /**
+     * Handle the rise-component-done event.
+     */
+    _handleDone: function(e) {
+      // Find the playlist item that fired the event.
+      for (var index = 0; index < this._items.length; index++) {
+        if (this._items[index].id === e.target.id) {
+          this._playNext(index);
+
+          break;
+        }
+      }
+
+      e.stopPropagation();
     },
 
     /************************************** HELPER FUNCTIONS **************************************/
@@ -281,6 +289,13 @@
       }
 
       return duration * 1000;
+    },
+
+    /**
+     * Get the index of the next playlist item.
+     */
+    _getNextIndex: function(index) {
+      return (index + 1 < this._items.length) ? (index + 1): 0;
     },
 
     /**

--- a/test/index.html
+++ b/test/index.html
@@ -13,7 +13,7 @@
       WCT.loadSuites([
         "integration/rise-playlist-content-sync.html",
         "integration/rise-playlist-item-visibility.html",
-        "unit/rise-playlist-content-sync.html",
+        "unit/rise-playlist-helper.html",
         "unit/rise-playlist.html"
       ]);
     </script>

--- a/test/integration/rise-playlist-content-sync.html
+++ b/test/integration/rise-playlist-content-sync.html
@@ -66,39 +66,6 @@
         assert(item1.style.display === "none", "item-1 is hidden");
         assert(item2.style.display === "none", "item-2 is hidden");
       });
-
-      test("should hide item-1 for its entire duration", function() {
-        assert(item1.style.display === "none", "item-1 is hidden");
-
-        clock.tick(9999);
-
-        assert(item1.style.display === "none", "item-1 is still hidden");
-      });
-
-      test("should play and show item-2", function() {
-        assert(item2.style.display === "none", "item-2 is hidden");
-        assert(playSpy.notCalled, "item-2 is not playing");
-
-        clock.tick(1);
-
-        assert(item2.style.display === "block", "item-2 is visible");
-        assert(playSpy.calledOnce, "item-2 is playing");
-      });
-
-      test("should pause and hide item-2", function() {
-        clock.tick(5000);
-
-        assert(item2.style.display === "none", "item-2 is hidden");
-        assert(pauseSpy.calledOnce, "item-2 is paused");
-      });
-
-      test("should hide item-1 for its entire duration after the last playlist item has finished", function() {
-        assert(item1.style.display === "none", "item-1 is hidden");
-
-        clock.tick(9999);
-
-        assert(item1.style.display === "none", "item-1 is still hidden");
-      });
     });
   </script>
 </body>

--- a/test/integration/rise-playlist-item-visibility.html
+++ b/test/integration/rise-playlist-item-visibility.html
@@ -40,6 +40,7 @@
       suiteSetup(function() {
         first.onReady();
         second.onReady();
+        playlist.play(0);
       });
 
       suiteTeardown(function() {
@@ -52,7 +53,7 @@
         });
 
         test("should apply outro class to first playlist item once it has completed playback", function() {
-          clock.tick(10000);
+          playlist._playNext(0);
 
           assert.isTrue(first.classList.contains("fade-out"));
         });

--- a/test/unit/rise-playlist-helper.html
+++ b/test/unit/rise-playlist-helper.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-  <title>Playlist - Content Sync</title>
+  <title>Playlist - Helper</title>
 
   <script src="../../../webcomponentsjs/webcomponents-lite.min.js"></script>
   <script src="../../../web-component-tester/browser.js"></script>
@@ -92,6 +92,16 @@
         });
       });
 
+      suite("_getItem", function() {
+        test("should return the correct playlist item for a valid index", function() {
+          assert.deepEqual(playlist._getItem(0), playlist._items[0]);
+        });
+
+        test("should return null for an invalid index", function() {
+          assert.isNull(playlist._getItem(2));
+        });
+      });
+
       suite("_getDuration", function() {
         test("should return correct duration of a playlist item", function() {
           assert.equal(playlist._getDuration(singleItem), 10000);
@@ -105,6 +115,19 @@
           assert.equal(playlist._getDuration(multipleItems), 0);
         });
       });
+
+      suite("_getNextIndex", function() {
+        test("should return the index of the next item", function() {
+          assert.equal(playlist._getNextIndex(0), 1);
+        });
+
+        test("should return the index of the first item when the current index references the " +
+          "last item of a playlist", function() {
+          assert.equal(playlist._getNextIndex(1), 0);
+        });
+      });
+
+      // TODO: Move _hideAll, _hide, _show and _sendCommand tests into this file.
     });
   </script>
 </body>

--- a/test/unit/rise-playlist.html
+++ b/test/unit/rise-playlist.html
@@ -137,9 +137,25 @@
         test("should show playlist item when played", function() {
           assert.equal(first.style.display, "block");
         });
+      });
 
-        test("should hide all other playlist items", function() {
-          assert.equal(second.style.display, "none");
+      suite("_suspend", function() {
+        suiteSetup(function() {
+          pauseSpy = sinon.spy(playlist._items[0], "pause");
+        });
+
+        suiteTeardown(function() {
+          playlist._items[0].pause.restore();
+        });
+
+        test("should pause playlist item", function() {
+          playlist._suspend(0, "pause");
+
+          assert(pauseSpy.calledOnce);
+        });
+
+        test("should hide playlist item when paused", function() {
+          assert.equal(first.style.display, "none");
         });
       });
 
@@ -147,34 +163,20 @@
         suiteSetup(function() {
           pauseSpy = sinon.spy(playlist._items[0], "pause");
           playSpy = sinon.spy(playlist._items[1], "play");
-          stopSpy = sinon.spy(playlist._items[1], "stop");
         });
 
         suiteTeardown(function() {
           playlist._items[0].pause.restore();
           playlist._items[1].play.restore();
-          playlist._items[0].play.restore();
-          playlist._items[1].stop.restore();
         });
 
         test("should pause playlist item", function() {
-          playlist._playNext(0, "pause");
+          playlist._playNext(0);
 
           assert(pauseSpy.calledOnce);
         });
 
-        test("should play next playlist item when paused", function() {
-          assert(playSpy.calledOnce);
-        });
-
-        test("should stop playlist item", function() {
-          playSpy = sinon.spy(playlist._items[0], "play");
-          playlist._playNext(1, "stop");
-
-          assert(stopSpy.calledOnce);
-        });
-
-        test("should play next playlist item when stopped", function() {
+        test("should play next playlist item", function() {
           assert(playSpy.calledOnce);
         });
       });
@@ -182,12 +184,10 @@
       suite("pause", function() {
         suiteSetup(function() {
           pauseSpy = sinon.spy(playlist._items[0], "pause");
-          playSpy = sinon.spy(playlist._items[1], "play");
         });
 
         suiteTeardown(function() {
           playlist._items[0].pause.restore();
-          playlist._items[1].play.restore();
         });
 
         test("should pause the current playlist item", function() {
@@ -196,20 +196,18 @@
           assert(pauseSpy.calledOnce);
         });
 
-        test("should play the next playlist item", function() {
-          assert(playSpy.calledOnce);
+        test("should hide the current playlist item", function() {
+          assert(playlist._items[0].element.style.display === "none");
         });
       });
 
       suite("stop", function() {
         suiteSetup(function() {
           stopSpy = sinon.spy(playlist._items[0], "stop");
-          playSpy = sinon.spy(playlist._items[1], "play");
         });
 
         suiteTeardown(function() {
           playlist._items[0].stop.restore();
-          playlist._items[1].play.restore();
         });
 
         test("should stop the current playlist item", function() {
@@ -218,8 +216,8 @@
           assert(stopSpy.calledOnce);
         });
 
-        test("should play the next playlist item", function() {
-          assert(playSpy.calledOnce);
+        test("should hide the current playlist item", function() {
+          assert(playlist._items[0].element.style.display === "none");
         });
       });
 


### PR DESCRIPTION
Playback of a playlist is now controlled externally via the `rise-page` component. Playlist fires the `rise-playlist-ready` event after all items have loaded or the loading timer expires. The only time `rise-playlist` handles its own playback is when a playlist has items that are PUD, in which case it's not possible to synchronize content and so `rise-page` doesn't need to control playback.
