### PR TITLE
Add distribution content tag

### DIFF
--- a/rise-playlist.html
+++ b/rise-playlist.html
@@ -5,6 +5,7 @@
 <dom-module id="rise-playlist">
   <template>
     <content id="items" select="rise-playlist-item"></content>
+    <content id="distribution" select="rise-distribution"></content>
   </template>
 </dom-module>
 


### PR DESCRIPTION
In order to gain access to the `rise-distribution` element from inside of `rise-page`, it needs to be made visible in `rise-playlist`.
